### PR TITLE
[add] NSCopying protocol support to TNCheckBoxData class and subclasses

### DIFF
--- a/src/TNCheckBoxData.h
+++ b/src/TNCheckBoxData.h
@@ -8,7 +8,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface TNCheckBoxData : NSObject
+@interface TNCheckBoxData : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSString *identifier;
 @property (nonatomic) NSInteger tag;

--- a/src/TNCheckBoxData.m
+++ b/src/TNCheckBoxData.m
@@ -10,6 +10,32 @@
 
 @implementation TNCheckBoxData
 
+#pragma mark - Copying
+- (id)copyWithZone:(NSZone *)zone
+{
+    TNCheckBoxData *copy = [[[self class] allocWithZone:zone] init];
+    
+    if (copy) {
+        copy.identifier = self.identifier;
+        copy.tag = self.tag;
+        copy.checked = self.checked;
+        
+        copy.labelText = self.labelText;
+        copy.labelFont = self.labelFont;
+        copy.labelColor = self.labelColor;
+        
+        copy.labelMarginLeft = self.labelMarginLeft;
+        copy.labelWidth = self.labelWidth;
+        copy.labelHeight = self.labelHeight;
+        
+        copy.labelBorderWidth = self.labelBorderWidth;
+        copy.labelBorderCornerRadius = self.labelBorderCornerRadius;
+        copy.labelBorderColor = self.labelBorderColor;
+    }
+    
+    return copy;
+}
+
 #pragma mark - Debug
 - (NSString *)description {
     return [NSString stringWithFormat:@"[TNCheckBoxData] Identifier: %@ - Tag: %i - Checked: %d", self.identifier, self.tag, self.checked];

--- a/src/TNCircularCheckBoxData.m
+++ b/src/TNCircularCheckBoxData.m
@@ -10,6 +10,22 @@
 
 @implementation TNCircularCheckBoxData
 
+#pragma mark - Copying
+- (id)copyWithZone:(NSZone *)zone
+{
+    TNCircularCheckBoxData *copy = [super copyWithZone:zone];
+    
+    if (copy) {
+        copy.borderColor = self.borderColor;
+        copy.circleColor = self.circleColor;
+        
+        copy.borderRadius = self.borderRadius;
+        copy.circleRadius = self.circleRadius;
+    }
+    
+    return copy;
+}
+
 #pragma mark - Getters and setters
 - (UIColor *)borderColor {
     

--- a/src/TNFillCheckBoxData.m
+++ b/src/TNFillCheckBoxData.m
@@ -10,4 +10,17 @@
 
 @implementation TNFillCheckBoxData
 
+#pragma mark - Copying
+- (id)copyWithZone:(NSZone *)zone
+{
+    TNFillCheckBoxData *copy = [super copyWithZone:zone];
+    
+    if (copy) {
+        copy.labelBgNormalColor = self.labelBgNormalColor;
+        copy.labelBgSelectedColor = self.labelBgSelectedColor;
+    }
+    
+    return copy;
+}
+
 @end

--- a/src/TNImageCheckBoxData.m
+++ b/src/TNImageCheckBoxData.m
@@ -10,4 +10,17 @@
 
 @implementation TNImageCheckBoxData
 
+#pragma mark - Copying
+- (id)copyWithZone:(NSZone *)zone
+{
+    TNImageCheckBoxData *copy = [super copyWithZone:zone];
+    
+    if (copy) {
+        copy.checkedImage = self.checkedImage;
+        copy.uncheckedImage = self.uncheckedImage;
+    }
+    
+    return copy;
+}
+
 @end

--- a/src/TNRectangularCheckBoxData.m
+++ b/src/TNRectangularCheckBoxData.m
@@ -10,6 +10,24 @@
 
 @implementation TNRectangularCheckBoxData
 
+#pragma mark - Copying
+- (id)copyWithZone:(NSZone *)zone
+{
+    TNRectangularCheckBoxData *copy = [super copyWithZone:zone];
+    
+    if (copy) {
+        copy.borderColor = self.borderColor;
+        copy.rectangleColor = self.rectangleColor;
+        
+        copy.borderWidth = self.borderWidth;
+        copy.borderHeight = self.borderHeight;
+        copy.rectangleWidth = self.rectangleWidth;
+        copy.rectangleHeight = self.rectangleHeight;
+    }
+    
+    return copy;
+}
+
 #pragma mark - Getters and setters
 - (UIColor *)borderColor {
     


### PR DESCRIPTION
I would like to use it this way:

```
TNCircularCheckBoxData *adminCan = [[TNCircularCheckBoxData alloc] init];
adminCan.identifier = @"adminCan";
adminCan.labelText = @"Only admin can invite members";
adminCan.labelColor = [UIColor colorWithWhite:74/255. alpha:1.0];
adminCan.labelWidth = 220;
adminCan.checked = YES;
adminCan.borderColor = [UIColor colorWithWhite:216/255. alpha:1.0];
adminCan.circleColor = [UIColor colorWithRed:0 green:200/255. blue:83/255. alpha:1.0];
adminCan.borderRadius = 30;
adminCan.circleRadius = 24;

TNCircularCheckBoxData *everyoneCan = [adminCan copy];
everyoneCan.identifier = @"everyoneCan";
everyoneCan.labelText = @"Everyone can invite members";
everyoneCan.checked = NO;
```
