### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ The current version supports 3 different checkboxes:
 Installation
 =============
 
-##Manual
+## Manual
 * Just drag the files in the src folder to your project.
 * Import the checkbox class you want to use.
 
-##Cocoapods
+## Cocoapods
 * Add ``` pod 'TNCheckBoxGroup' ``` to your Podfile.
 * Done.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
